### PR TITLE
Repository and network source implementation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ChatBot"
+        tools:targetApi="31" >
+    </application>
+</manifest>

--- a/app/src/main/java/fr/poveda/chatbot/data/DefaultRepository.kt
+++ b/app/src/main/java/fr/poveda/chatbot/data/DefaultRepository.kt
@@ -1,0 +1,19 @@
+package fr.poveda.chatbot.data
+
+import fr.poveda.chatbot.data.model.Message
+import fr.poveda.chatbot.data.source.network.INetworkDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Default implementation of [IRepository]
+ *  Single entry point for managing conversation data.
+ */
+class DefaultRepository @Inject constructor(private val networkDataSource: INetworkDataSource) : IRepository {
+    override suspend fun getBotResponse(message: Message): Message {
+        return withContext(Dispatchers.IO) {
+            networkDataSource.getResponse(message)
+        }
+    }
+}

--- a/app/src/main/java/fr/poveda/chatbot/data/IRepository.kt
+++ b/app/src/main/java/fr/poveda/chatbot/data/IRepository.kt
@@ -1,0 +1,7 @@
+package fr.poveda.chatbot.data
+
+import fr.poveda.chatbot.data.model.Message
+
+interface IRepository {
+    suspend fun getBotResponse(message: Message) : Message
+}

--- a/app/src/main/java/fr/poveda/chatbot/data/model/Author.kt
+++ b/app/src/main/java/fr/poveda/chatbot/data/model/Author.kt
@@ -1,3 +1,8 @@
 package fr.poveda.chatbot.data.model
 
-data class Author(val name: String)
+data class Author(val name: String) {
+    companion object {
+        const val BOT_NAME = "bot"
+        const val USER_NAME = "user"
+    }
+}

--- a/app/src/main/java/fr/poveda/chatbot/data/source/network/INetworkDataSource.kt
+++ b/app/src/main/java/fr/poveda/chatbot/data/source/network/INetworkDataSource.kt
@@ -1,0 +1,10 @@
+package fr.poveda.chatbot.data.source.network
+
+import fr.poveda.chatbot.data.model.Message
+
+/**
+ * Main entry point for accessing bot message responses from the network.
+ */
+interface INetworkDataSource {
+    suspend fun getResponse(message: Message): Message
+}

--- a/app/src/main/java/fr/poveda/chatbot/data/source/network/MockedNetworkServer.kt
+++ b/app/src/main/java/fr/poveda/chatbot/data/source/network/MockedNetworkServer.kt
@@ -1,0 +1,54 @@
+package fr.poveda.chatbot.data.source.network
+
+import fr.poveda.chatbot.data.model.Author
+import fr.poveda.chatbot.data.model.Message
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+import kotlin.random.Random
+
+class MockedNetworkServer @Inject constructor(): INetworkDataSource {
+    private var serviceLatencyInMillis = Random.nextLong(1000L, 2500L)
+    private val bot = Author(Author.BOT_NAME)
+    private val botOpeningReponses = mutableListOf(
+        "Hello, how are you ?",
+        "Why are you coming to see me?",
+        "Please tell me what's been bothering you.",
+        "Is something troubling you ?",
+        "Why are you asking that ?",
+        )
+    private val botComputerAnswerReponses = mutableListOf(
+        "Are you telling that because i'm a computer ?",
+        "What do you think about machines ?",
+        "You know, computer have feelings too",
+        )
+    private val botOtherResponses = mutableListOf(
+        "That is interesting. Please continue.",
+        "Tell me, how are you today ?",
+        "If aliens exists, why they did not already contacted us ?"
+    )
+
+    private suspend fun getBotMessage(message: Message) : Message {
+        delay(serviceLatencyInMillis)
+        return when {
+            message.content.contains("computer", ignoreCase = true) -> {
+                Message(bot, botComputerAnswerReponses.random())
+            }
+            message.content.contains("hello", ignoreCase = true) -> {
+                Message(bot, botOpeningReponses.random())
+            }
+            else -> {
+                Message(bot, botOtherResponses.random())
+            }
+        }
+    }
+
+    override suspend fun getResponse(message: Message): Message {
+        return coroutineScope {
+            val botMessage = async(Dispatchers.Default) { getBotMessage(message) }
+            botMessage.await()
+        }
+    }
+}

--- a/app/src/test/java/fr/poveda/chatbot/data/DefaultRepositoryUnitTest.kt
+++ b/app/src/test/java/fr/poveda/chatbot/data/DefaultRepositoryUnitTest.kt
@@ -1,0 +1,78 @@
+package fr.poveda.chatbot.data
+
+import fr.poveda.chatbot.data.model.Author
+import fr.poveda.chatbot.data.model.Message
+import fr.poveda.chatbot.data.source.network.INetworkDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultRepositoryUnitTest {
+    private lateinit var defaultRepository: DefaultRepository
+    private lateinit var fakeMockedNetworkServer: FakeMockedNetworkServer
+    private val userAuthor = Author(Author.USER_NAME)
+    private val message1 = Message(userAuthor, "ola")
+    private val message2 = Message(userAuthor, "this is a test")
+    private val message3 = Message(userAuthor, "are you a real person ?")
+    private val messageList = listOf(message1, message2, message3)
+
+    @ExperimentalCoroutinesApi
+    val testDispatcher = StandardTestDispatcher()
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeMockedNetworkServer = FakeMockedNetworkServer()
+        defaultRepository = DefaultRepository(fakeMockedNetworkServer)
+    }
+
+    @Test
+    fun defaultRepository_getBotResponse_test() = runTest {
+        val responseMessage = defaultRepository.getBotResponse(message1)
+        advanceUntilIdle()
+        Assert.assertNotNull(responseMessage)
+    }
+
+    @Test
+    fun defaultRepository_multipleGetBotResponse_test() = runTest {
+        for (message in messageList) {
+            launch {
+                val responseMessage = defaultRepository.getBotResponse(message)
+                Assert.assertNotNull(responseMessage)
+                Assert.assertNotNull(responseMessage.content)
+                Assert.assertEquals(Author.BOT_NAME, responseMessage.author.name)
+            }
+        }
+        advanceUntilIdle()
+    }
+
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDownDispatcher() {
+        Dispatchers.resetMain()
+    }
+}
+
+private class FakeMockedNetworkServer : INetworkDataSource {
+    private val data = "fakeData"
+
+    override suspend fun getResponse(message: Message): Message {
+        return coroutineScope {
+            val botMessage = async(Dispatchers.Default) { Message(Author(Author.BOT_NAME), data) }
+            botMessage.await()
+        }
+    }
+}

--- a/app/src/test/java/fr/poveda/chatbot/data/MockedNetworkServerUnitTest.kt
+++ b/app/src/test/java/fr/poveda/chatbot/data/MockedNetworkServerUnitTest.kt
@@ -1,0 +1,64 @@
+package fr.poveda.chatbot.data
+
+import fr.poveda.chatbot.data.model.Author
+import fr.poveda.chatbot.data.model.Message
+import fr.poveda.chatbot.data.source.network.MockedNetworkServer
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MockedNetworkServerUnitTest {
+    private lateinit var mockedNetworkServer: MockedNetworkServer
+    private val userAuthor = Author(Author.USER_NAME)
+    private val message1 = Message(userAuthor, "ola")
+    private val message2 = Message(userAuthor, "this is a test")
+    private val message3 = Message(userAuthor, "are you a real person ?")
+    private val messageList = listOf(message1, message2, message3)
+
+    @ExperimentalCoroutinesApi
+    val testDispatcher = StandardTestDispatcher()
+
+    @ExperimentalCoroutinesApi
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        mockedNetworkServer = MockedNetworkServer()
+    }
+
+    @Test
+    fun mockedNetworkServer_getResponse_test() = runTest {
+        val responseMessage = mockedNetworkServer.getResponse(message1)
+        advanceUntilIdle()
+        assertNotNull(responseMessage)
+    }
+
+    @Test
+    fun mockedNetworkServer_multipleGetResponse_test() = runTest {
+        for (message in messageList) {
+            launch {
+                val responseMessage = mockedNetworkServer.getResponse(message)
+                assertNotNull(responseMessage)
+                assertNotNull(responseMessage.content)
+                assertEquals(Author.BOT_NAME, responseMessage.author.name)
+            }
+        }
+        advanceUntilIdle()
+    }
+
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDownDispatcher() {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
Add a default repository to retrieve bot response from a network source.
Add a mock server as network source to generate the bot response. 
Add tests for the default repository and the mock server.